### PR TITLE
Backport DNG SDK 1.7.1 support in SkRawCodec

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2182,7 +2182,6 @@ cc_defaults {
     name: "skia_deps",
     defaults: ["skia_renderengine_deps"],
     shared_libs: [
-        "libdng_sdk",
         "libjpeg",
         "libpiex",
         "libexpat",
@@ -2205,14 +2204,23 @@ cc_defaults {
       android: {
         shared_libs: [
             "libmediandk", // Needed to link libcrabbyavif_ffi in some configurations.
+            "libdng_sdk",
         ],
         whole_static_libs: [
             "libcrabbyavif_ffi",
         ],
       },
+      host_linux: {
+        static_libs: [
+            "libdng_sdk",
+        ],
+      },
       darwin: {
         host_ldlibs: [
             "-framework AppKit",
+        ],
+        static_libs: [
+            "libdng_sdk",
         ],
       },
       windows: {

--- a/src/codec/SkRawCodec.cpp
+++ b/src/codec/SkRawCodec.cpp
@@ -124,7 +124,7 @@ class SkDngHost : public dng_host {
 public:
     explicit SkDngHost(dng_memory_allocator* allocater) : dng_host(allocater) {}
 
-    void PerformAreaTask(dng_area_task& task, const dng_rect& area) override {
+    void PerformAreaTask(dng_area_task& task, const dng_rect& area, dng_area_task_progress*) override {
         SkTaskGroup taskGroup;
 
         // tileSize is typically 256x256
@@ -135,11 +135,11 @@ public:
 
         SkMutex mutex;
         TArray<dng_exception> exceptions;
-        task.Start(numTasks, tileSize, &Allocator(), Sniffer());
+        task.Start(numTasks, area, tileSize, &Allocator(), Sniffer());
         for (int taskIndex = 0; taskIndex < numTasks; ++taskIndex) {
             taskGroup.add([&mutex, &exceptions, &task, this, taskIndex, taskAreas, tileSize] {
                 try {
-                    task.ProcessOnThread(taskIndex, taskAreas[taskIndex], tileSize, this->Sniffer());
+                    task.ProcessOnThread(taskIndex, taskAreas[taskIndex], tileSize, this->Sniffer(), nullptr);
                 } catch (dng_exception& exception) {
                     SkAutoMutexExclusive lock(mutex);
                     exceptions.push_back(exception);
@@ -435,7 +435,13 @@ private:
 class SkDngStream : public dng_stream {
 public:
     // Will NOT take the ownership of the stream.
-    SkDngStream(SkRawStream* stream) : fStream(stream) {}
+    SkDngStream(SkRawStream* stream)
+            // The default constructor sets offsetInOriginalFile to invalid (-1), however
+            // this results in dng_negative hitting a bug path that causes a crash due to
+            // unsigned overflow occuring. This offset doesn't seem to serve any purpose,
+            // so just pretend we're always at the start of the file to avoid the crash
+            : dng_stream((dng_abort_sniffer*) nullptr, dng_stream::kDefaultBufferSize, 0)
+            , fStream(stream) {}
 
     ~SkDngStream() override {}
 


### PR DESCRIPTION
Bug: 412662901
Test: make, otherwise clean cherry-pick of main's version

Changes coming from ag/34978263
Cherrypick-From: https://googleplex-android-review.googlesource.com/q/commit:de30f7a7bab7a58fbe54f36ccb5b161b81c09ae9 Merged-In: I6234ef0f2afa3838f81d7794c943a7e3c8ba9f82 Change-Id: I6234ef0f2afa3838f81d7794c943a7e3c8ba9f82